### PR TITLE
Bootstrap Verse Seed/Bloom shell prototype

### DIFF
--- a/dist/compiler.js
+++ b/dist/compiler.js
@@ -1,0 +1,354 @@
+export const ENGINE_VERSION = "2024.05-seed";
+
+export function compileSeed(seed, mode, engineVersion = ENGINE_VERSION) {
+  const tokens = tokenize(seed);
+  const params = mode === "seed" ? compileSeedMode(tokens) : compileBloomMode(tokens);
+  const signature = sha256(`${seed}|${engineVersion}|${JSON.stringify(params)}`);
+  return { params, engineVersion, signature };
+}
+
+export const DEFAULT_PARAMS = {
+  shape: "field",
+  tide: 0.5,
+  tremor: 0.2,
+  trails: 0.6,
+  pull: 0.4,
+  count: 64,
+  herald: false,
+  tempoHz: 1.0,
+};
+
+const TOKEN_EFFECTS = {
+  ring: { set: { shape: "circle" }, delta: { pull: 0.2 } },
+  spiral: { set: { shape: "spiral" }, delta: { tide: 0.25 } },
+  wave: { set: { shape: "wave" } },
+  line: { set: { shape: "line" } },
+  static: { delta: { tremor: 0.25 } },
+  noise: { delta: { tremor: 0.25 } },
+  scatter: { delta: { tremor: 0.25 } },
+  slow: { set: { tide: 0.25 } },
+  fast: { set: { tide: 0.75 } },
+  calm: { set: { tide: 0.3 } },
+  rush: { set: { tide: 0.85 } },
+  short: { set: { trails: 0.3 } },
+  long: { set: { trails: 0.85 } },
+  ghost: { set: { trails: 0.95 } },
+  trails: { delta: { trails: 0.1 } },
+  few: { set: { count: 12 } },
+  some: { set: { count: 32 } },
+  many: { set: { count: 128 } },
+  thousand: { set: { count: 1000 } },
+  herald: { set: { herald: true, count: 1 } },
+  red: { set: { herald: true, count: 1 } },
+  tempo: { set: { tempoHz: 1.0 } },
+  pulse: { set: { tempoHz: 2.0 } },
+  breathe: { set: { tempoHz: 0.5 } },
+  beat: { set: { tempoHz: 1.5 } },
+};
+
+const NUMBER_PATTERN = /^\d+$/;
+
+function tokenize(seed) {
+  return seed
+    .toLowerCase()
+    .split(/[^a-z0-9]+/g)
+    .map((token) => token.trim())
+    .filter(Boolean);
+}
+
+function compileSeedMode(tokens) {
+  const accumulator = {
+    shape: { value: DEFAULT_PARAMS.shape, conflict: false, applied: false },
+    tide: { value: DEFAULT_PARAMS.tide, conflict: false, applied: false },
+    tremor: { value: DEFAULT_PARAMS.tremor, conflict: false, applied: false },
+    trails: { value: DEFAULT_PARAMS.trails, conflict: false, applied: false },
+    pull: { value: DEFAULT_PARAMS.pull, conflict: false, applied: false },
+    count: { value: DEFAULT_PARAMS.count, conflict: false, applied: false },
+    herald: { value: DEFAULT_PARAMS.herald, conflict: false, applied: false },
+    tempoHz: { value: DEFAULT_PARAMS.tempoHz, conflict: false, applied: false },
+  };
+
+  tokens.forEach((token) => {
+    if (NUMBER_PATTERN.test(token)) {
+      applySeedValue(accumulator, "count", parseInt(token, 10));
+      return;
+    }
+
+    if (token === "tempo" && tokens.includes("hz")) {
+      return;
+    }
+
+    const effect = TOKEN_EFFECTS[token];
+    if (!effect) {
+      return;
+    }
+
+    if (effect.set) {
+      Object.entries(effect.set).forEach(([key, rawValue]) => {
+        applySeedValue(accumulator, key, rawValue);
+      });
+    }
+
+    if (effect.delta) {
+      Object.entries(effect.delta).forEach(([key, delta]) => {
+        const entry = accumulator[key];
+        if (typeof entry.value === "number") {
+          entry.value = clampNumber(entry.value + delta, 0, 1.5);
+          entry.applied = true;
+        }
+      });
+    }
+  });
+
+  Object.keys(accumulator).forEach((key) => {
+    const entry = accumulator[key];
+    if (entry.conflict) {
+      entry.value = DEFAULT_PARAMS[key];
+    }
+  });
+
+  return {
+    shape: accumulator.shape.value,
+    tide: accumulator.tide.value,
+    tremor: accumulator.tremor.value,
+    trails: accumulator.trails.value,
+    pull: accumulator.pull.value,
+    count: accumulator.count.value,
+    herald: accumulator.herald.value,
+    tempoHz: accumulator.tempoHz.value,
+  };
+}
+
+function applySeedValue(accumulator, key, value) {
+  const entry = accumulator[key];
+  if (!entry.applied) {
+    entry.value = value;
+    entry.applied = true;
+    return;
+  }
+  if (isSame(entry.value, value)) {
+    return;
+  }
+  entry.conflict = true;
+}
+
+function compileBloomMode(tokens) {
+  const accumulator = {
+    shape: { contributions: [] },
+    tide: { contributions: [] },
+    tremor: { contributions: [] },
+    trails: { contributions: [] },
+    pull: { contributions: [] },
+    count: { contributions: [] },
+    herald: { contributions: [] },
+    tempoHz: { contributions: [] },
+  };
+
+  tokens.forEach((token) => {
+    if (NUMBER_PATTERN.test(token)) {
+      accumulator.count.contributions.push({ value: parseInt(token, 10), weight: 1 });
+      return;
+    }
+
+    if (token === "tempo" && tokens.includes("hz")) {
+      return;
+    }
+
+    const effect = TOKEN_EFFECTS[token];
+    if (!effect) {
+      return;
+    }
+
+    if (effect.set) {
+      Object.entries(effect.set).forEach(([key, rawValue]) => {
+        accumulator[key].contributions.push({ value: rawValue, weight: 1 });
+      });
+    }
+
+    if (effect.delta) {
+      Object.entries(effect.delta).forEach(([key, delta]) => {
+        const base = DEFAULT_PARAMS[key];
+        accumulator[key].contributions.push({ value: base + delta, weight: 0.6 });
+      });
+    }
+  });
+
+  return {
+    shape: pickMode(accumulator.shape, DEFAULT_PARAMS.shape),
+    tide: blendNumeric(accumulator.tide, DEFAULT_PARAMS.tide),
+    tremor: blendNumeric(accumulator.tremor, DEFAULT_PARAMS.tremor),
+    trails: blendNumeric(accumulator.trails, DEFAULT_PARAMS.trails),
+    pull: blendNumeric(accumulator.pull, DEFAULT_PARAMS.pull),
+    count: blendNumeric(accumulator.count, DEFAULT_PARAMS.count, { clampMax: 2000 }),
+    herald: blendBoolean(accumulator.herald, DEFAULT_PARAMS.herald),
+    tempoHz: blendNumeric(accumulator.tempoHz, DEFAULT_PARAMS.tempoHz, { clampMax: 6 }),
+  };
+}
+
+function pickMode(entry, fallback) {
+  if (entry.contributions.length === 0) {
+    return fallback;
+  }
+  const buckets = new Map();
+  entry.contributions.forEach(({ value, weight }) => {
+    buckets.set(value, (buckets.get(value) ?? 0) + weight);
+  });
+  let best = fallback;
+  let bestWeight = -Infinity;
+  buckets.forEach((weight, key) => {
+    if (weight > bestWeight) {
+      bestWeight = weight;
+      best = key;
+    }
+  });
+  return best;
+}
+
+function blendNumeric(entry, fallback, options = {}) {
+  if (entry.contributions.length === 0) {
+    return fallback;
+  }
+  let weightSum = 0;
+  let weightedValue = 0;
+  entry.contributions.forEach(({ value, weight }) => {
+    weightSum += weight;
+    weightedValue += value * weight;
+  });
+  const raw = weightSum > 0 ? weightedValue / weightSum : fallback;
+  const min = options.clampMin ?? 0;
+  const max = options.clampMax ?? 1.5;
+  return clampNumber(raw, min, max);
+}
+
+function blendBoolean(entry, fallback) {
+  if (entry.contributions.length === 0) {
+    return fallback;
+  }
+  let score = fallback ? 0.5 : 0;
+  entry.contributions.forEach(({ value, weight }) => {
+    score += (value ? 1 : -1) * weight;
+  });
+  return score > 0.5;
+}
+
+function clampNumber(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function isSame(current, next) {
+  if (typeof current === "number" && typeof next === "number") {
+    return Math.abs(current - next) < 1e-6;
+  }
+  return current === next;
+}
+
+function sha256(input) {
+  const data = new TextEncoder().encode(input);
+  const hash = sha256Buffer(data);
+  return Array.from(hash)
+    .map((value) => value.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function sha256Buffer(data) {
+  const K = new Uint32Array([
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+  ]);
+
+  const H = new Uint32Array([
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+  ]);
+
+  const padded = pad(data);
+  const view = new DataView(padded.buffer);
+  const w = new Uint32Array(64);
+
+  for (let offset = 0; offset < padded.byteLength; offset += 64) {
+    for (let i = 0; i < 16; i += 1) {
+      w[i] = view.getUint32(offset + i * 4);
+    }
+    for (let i = 16; i < 64; i += 1) {
+      const s0 = rightRotate(w[i - 15], 7) ^ rightRotate(w[i - 15], 18) ^ (w[i - 15] >>> 3);
+      const s1 = rightRotate(w[i - 2], 17) ^ rightRotate(w[i - 2], 19) ^ (w[i - 2] >>> 10);
+      w[i] = (w[i - 16] + s0 + w[i - 7] + s1) >>> 0;
+    }
+
+    let a = H[0];
+    let b = H[1];
+    let c = H[2];
+    let d = H[3];
+    let e = H[4];
+    let f = H[5];
+    let g = H[6];
+    let h = H[7];
+
+    for (let i = 0; i < 64; i += 1) {
+      const S1 = rightRotate(e, 6) ^ rightRotate(e, 11) ^ rightRotate(e, 25);
+      const ch = (e & f) ^ (~e & g);
+      const temp1 = (h + S1 + ch + K[i] + w[i]) >>> 0;
+      const S0 = rightRotate(a, 2) ^ rightRotate(a, 13) ^ rightRotate(a, 22);
+      const maj = (a & b) ^ (a & c) ^ (b & c);
+      const temp2 = (S0 + maj) >>> 0;
+
+      h = g;
+      g = f;
+      f = e;
+      e = (d + temp1) >>> 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (temp1 + temp2) >>> 0;
+    }
+
+    H[0] = (H[0] + a) >>> 0;
+    H[1] = (H[1] + b) >>> 0;
+    H[2] = (H[2] + c) >>> 0;
+    H[3] = (H[3] + d) >>> 0;
+    H[4] = (H[4] + e) >>> 0;
+    H[5] = (H[5] + f) >>> 0;
+    H[6] = (H[6] + g) >>> 0;
+    H[7] = (H[7] + h) >>> 0;
+  }
+
+  const out = new Uint8Array(32);
+  for (let i = 0; i < H.length; i += 1) {
+    out[i * 4] = (H[i] >>> 24) & 0xff;
+    out[i * 4 + 1] = (H[i] >>> 16) & 0xff;
+    out[i * 4 + 2] = (H[i] >>> 8) & 0xff;
+    out[i * 4 + 3] = H[i] & 0xff;
+  }
+  return out;
+}
+
+function pad(data) {
+  const length = data.length;
+  const withOne = new Uint8Array(length + 1);
+  withOne.set(data);
+  withOne[length] = 0x80;
+
+  let paddedLength = withOne.length;
+  while (paddedLength % 64 !== 56) {
+    paddedLength += 1;
+  }
+
+  const padded = new Uint8Array(paddedLength + 8);
+  padded.set(withOne);
+
+  const bitLength = length * 8;
+  for (let i = 0; i < 8; i += 1) {
+    padded[paddedLength + 7 - i] = bitLength >>> (i * 8);
+  }
+
+  return padded;
+}
+
+function rightRotate(value, bits) {
+  return (value >>> bits) | (value << (32 - bits));
+}

--- a/dist/engine.js
+++ b/dist/engine.js
@@ -1,0 +1,76 @@
+export class VerseEngine {
+  constructor(canvas) {
+    const context = canvas.getContext("2d", { alpha: false });
+    if (!context) {
+      throw new Error("Canvas 2D context unavailable");
+    }
+    this.canvas = canvas;
+    this.context = context;
+    this.animationFrame = null;
+    this.lastTimestamp = 0;
+    this.params = null;
+    this.configure();
+  }
+
+  configure() {
+    const { devicePixelRatio } = window;
+    const width = this.canvas.clientWidth;
+    const height = this.canvas.clientHeight;
+    this.canvas.width = Math.floor(width * devicePixelRatio);
+    this.canvas.height = Math.floor(height * devicePixelRatio);
+    this.context.scale(devicePixelRatio, devicePixelRatio);
+  }
+
+  setParams(params) {
+    this.params = params;
+  }
+
+  start() {
+    if (this.animationFrame !== null) {
+      return;
+    }
+    this.lastTimestamp = performance.now();
+    const tick = (timestamp) => {
+      const delta = timestamp - this.lastTimestamp;
+      this.lastTimestamp = timestamp;
+      this.draw({ timeMs: timestamp, deltaMs: delta });
+      this.animationFrame = window.requestAnimationFrame(tick);
+    };
+    this.animationFrame = window.requestAnimationFrame(tick);
+  }
+
+  stop() {
+    if (this.animationFrame !== null) {
+      window.cancelAnimationFrame(this.animationFrame);
+      this.animationFrame = null;
+    }
+  }
+
+  draw(frame) {
+    const { context, canvas } = this;
+    context.fillStyle = "rgba(8, 8, 12, 0.6)";
+    context.fillRect(0, 0, canvas.width, canvas.height);
+
+    if (!this.params) {
+      return;
+    }
+
+    const centerX = canvas.width / 2;
+    const centerY = canvas.height / 2;
+    const count = Math.max(1, Math.floor(this.params.count));
+    const radius = Math.min(centerX, centerY) * 0.6;
+    const tempo = this.params.tempoHz;
+    const time = frame.timeMs / 1000;
+
+    for (let i = 0; i < count; i += 1) {
+      const angle = ((i / count) * Math.PI * 2 + time * tempo) % (Math.PI * 2);
+      const jitter = this.params.tremor * Math.sin(time * 3.1 + i);
+      const x = centerX + Math.cos(angle) * (radius + jitter * 40);
+      const y = centerY + Math.sin(angle) * (radius + jitter * 40);
+      context.fillStyle = this.params.herald && i === 0 ? "#ff5555" : "#d0d7ff";
+      context.beginPath();
+      context.arc(x, y, this.params.pull * 6 + 2, 0, Math.PI * 2);
+      context.fill();
+    }
+  }
+}

--- a/dist/shell_keyboard.html
+++ b/dist/shell_keyboard.html
@@ -1,0 +1,420 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Verse Shell · Keyboard Prototype</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #05060a;
+        --panel: #10121a;
+        --panel-accent: #161924;
+        --border: rgba(255, 255, 255, 0.08);
+        --text: #edf1ff;
+        --muted: rgba(237, 241, 255, 0.6);
+        --highlight: rgba(102, 153, 255, 0.18);
+        --pill-bg: rgba(255, 255, 255, 0.1);
+        font-family: "SF Pro Display", "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: radial-gradient(circle at 20% 20%, #0f1330, #05060a 62%);
+        color: var(--text);
+        display: flex;
+        justify-content: center;
+      }
+
+      .app-shell {
+        width: min(100%, 1024px);
+        display: grid;
+        grid-template-rows: auto 1fr;
+        background: rgba(8, 10, 18, 0.72);
+        backdrop-filter: blur(24px);
+        border: 1px solid rgba(255, 255, 255, 0.04);
+        border-radius: 28px;
+        margin: 24px;
+        overflow: hidden;
+      }
+
+      header {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        padding: 16px 20px;
+        border-bottom: 1px solid var(--border);
+        background: rgba(15, 16, 24, 0.86);
+      }
+
+      header h1 {
+        font-size: 18px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        margin: 0;
+      }
+
+      .drawer-toggle {
+        height: 36px;
+        width: 36px;
+        border-radius: 12px;
+        border: 1px solid var(--border);
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+        color: var(--text);
+        display: grid;
+        place-items: center;
+        cursor: pointer;
+      }
+
+      .drawer-toggle:active {
+        background: rgba(255, 255, 255, 0.12);
+      }
+
+      .mode-buttons {
+        margin-left: auto;
+        display: inline-flex;
+        padding: 4px;
+        border-radius: 16px;
+        background: rgba(255, 255, 255, 0.06);
+        gap: 4px;
+      }
+
+      .mode-buttons button {
+        border: 0;
+        border-radius: 12px;
+        padding: 6px 16px;
+        font-size: 13px;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--muted);
+        background: transparent;
+        cursor: pointer;
+      }
+
+      .mode-buttons button.is-active {
+        color: var(--text);
+        background: rgba(102, 153, 255, 0.22);
+      }
+
+      .app-body {
+        display: grid;
+        grid-template-columns: 260px 1fr;
+        min-height: 640px;
+      }
+
+      .drawer {
+        background: rgba(9, 11, 18, 0.82);
+        border-right: 1px solid var(--border);
+        padding: 24px 20px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .drawer h2 {
+        margin: 0 0 8px;
+        font-size: 13px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--muted);
+      }
+
+      .drawer p {
+        margin: 0;
+        font-size: 14px;
+        line-height: 1.4;
+        color: rgba(237, 241, 255, 0.7);
+      }
+
+      .workspace {
+        display: grid;
+        grid-template-rows: minmax(200px, 1fr) auto auto auto;
+        background: linear-gradient(180deg, rgba(12, 15, 26, 0.88), rgba(6, 7, 12, 0.96));
+        padding: 24px;
+        gap: 18px;
+      }
+
+      .editor-stage {
+        border-radius: 20px;
+        border: 1px solid var(--border);
+        background: rgba(18, 20, 32, 0.7);
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .editor-title {
+        font-size: 12px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--muted);
+      }
+
+      .editor-display {
+        min-height: 120px;
+        border-radius: 16px;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        background: rgba(6, 8, 16, 0.65);
+        padding: 16px;
+        font-size: 18px;
+        line-height: 1.5;
+        letter-spacing: 0.01em;
+        position: relative;
+        overflow-wrap: break-word;
+      }
+
+      .editor-display::after {
+        content: "tap ◆ keyboard";
+        position: absolute;
+        right: 16px;
+        bottom: 16px;
+        font-size: 12px;
+        color: rgba(237, 241, 255, 0.38);
+      }
+
+      .editor-caret {
+        display: inline-block;
+        width: 2px;
+        background: rgba(102, 153, 255, 0.9);
+        animation: caret 1s step-start infinite;
+      }
+
+      @keyframes caret {
+        0%, 50% {
+          opacity: 1;
+        }
+        50.01%, 100% {
+          opacity: 0;
+        }
+      }
+
+      .suggestion-strip {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 12px;
+        align-items: center;
+      }
+
+      .suggestion-strip button {
+        height: 40px;
+        border-radius: 18px;
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        background: var(--pill-bg);
+        color: var(--text);
+        font-size: 14px;
+        letter-spacing: 0.02em;
+        cursor: pointer;
+      }
+
+      .suggestion-strip button.is-hidden {
+        visibility: hidden;
+      }
+
+      .keyboard-wrapper {
+        border-radius: 26px;
+        background: rgba(8, 9, 14, 0.92);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        padding: 12px 10px 20px;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+
+      .keyboard-row {
+        display: grid;
+        grid-auto-flow: column;
+        gap: 6px;
+        justify-content: center;
+        position: relative;
+      }
+
+      .keyboard-row[data-row="1"] {
+        height: 48px;
+        grid-template-columns: repeat(10, minmax(0, 1fr)) 1.2fr;
+      }
+
+      .keyboard-row[data-row="2"] {
+        height: 48px;
+        grid-template-columns: 0.5fr repeat(9, minmax(0, 1fr)) 1.2fr;
+      }
+
+      .keyboard-row[data-row="3"] {
+        height: 48px;
+        grid-template-columns: 1.2fr repeat(7, minmax(0, 1fr)) 1.2fr;
+      }
+
+      .keyboard-row[data-row="4"] {
+        height: 56px;
+        grid-template-columns: 1.3fr 1fr 4fr 1.3fr;
+      }
+
+      .vk-key {
+        border: 0;
+        border-radius: 12px;
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.02));
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
+        color: var(--text);
+        font-size: 18px;
+        font-weight: 500;
+        cursor: pointer;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        position: relative;
+        user-select: none;
+        -webkit-user-select: none;
+        touch-action: none;
+      }
+
+      .vk-key[data-role="wide"] {
+        border-radius: 14px;
+        font-size: 16px;
+      }
+
+      .vk-key.is-pressed {
+        transform: translateY(1px);
+        background: rgba(255, 255, 255, 0.18);
+      }
+
+      .vk-key.is-hover {
+        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
+      }
+
+      .vk-popover {
+        position: absolute;
+        top: -60px;
+        left: 50%;
+        transform: translateX(-50%);
+        display: flex;
+        gap: 6px;
+        background: rgba(12, 14, 22, 0.95);
+        border-radius: 14px;
+        padding: 8px;
+        box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+      }
+
+      .vk-popover-key {
+        min-width: 36px;
+        border-radius: 10px;
+        border: 0;
+        background: rgba(255, 255, 255, 0.12);
+        color: var(--text);
+        font-size: 16px;
+        padding: 8px 10px;
+      }
+
+      .compile-log {
+        border-radius: 16px;
+        background: rgba(6, 8, 14, 0.86);
+        border: 1px solid rgba(255, 255, 255, 0.06);
+        padding: 16px;
+        font-family: "SF Mono", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 12px;
+        line-height: 1.4;
+        color: rgba(237, 241, 255, 0.8);
+        white-space: pre-wrap;
+        min-height: 120px;
+      }
+
+      @media (max-width: 960px) {
+        .app-body {
+          grid-template-columns: minmax(0, 1fr);
+        }
+
+        .drawer {
+          display: none;
+        }
+
+        .drawer.is-open {
+          display: flex;
+        }
+      }
+    </style>
+    <script type="module" src="./ui/shell.js"></script>
+  </head>
+  <body>
+    <div class="app-shell">
+      <header>
+        <button class="drawer-toggle" data-shell-drawer-toggle aria-label="Toggle drawer">☰</button>
+        <h1>Verse · Seed / Bloom</h1>
+        <div class="mode-buttons">
+          <button type="button" class="is-active" data-mode="seed">Seed</button>
+          <button type="button" data-mode="bloom">Bloom</button>
+        </div>
+      </header>
+      <div class="app-body">
+        <aside class="drawer" data-shell-drawer>
+          <h2>Spellbook</h2>
+          <p>
+            Drop seeds under 280 characters. Seed mode compiles literal triggers; Bloom explores harmonics
+            while staying deterministic once compiled.
+          </p>
+        </aside>
+        <main class="workspace">
+          <section class="editor-stage">
+            <span class="editor-title">Seed Draft</span>
+            <div class="editor-display" data-editor-display></div>
+          </section>
+          <section class="suggestion-strip" data-suggestion-strip>
+            <button type="button" data-suggestion></button>
+            <button type="button" data-suggestion></button>
+            <button type="button" data-suggestion></button>
+          </section>
+          <section class="keyboard-wrapper" data-keyboard>
+            <div class="keyboard-row" data-row="1">
+              <button class="vk-key" type="button" data-key="q">Q</button>
+              <button class="vk-key" type="button" data-key="w">W</button>
+              <button class="vk-key" type="button" data-key="e" data-alternates="é|ê|ë">E</button>
+              <button class="vk-key" type="button" data-key="r">R</button>
+              <button class="vk-key" type="button" data-key="t">T</button>
+              <button class="vk-key" type="button" data-key="y">Y</button>
+              <button class="vk-key" type="button" data-key="u" data-alternates="ù|û">U</button>
+              <button class="vk-key" type="button" data-key="i" data-alternates="î|ï">I</button>
+              <button class="vk-key" type="button" data-key="o" data-alternates="ô|ö">O</button>
+              <button class="vk-key" type="button" data-key="p">P</button>
+              <button class="vk-key" type="button" data-action="backspace" data-role="wide">⌫</button>
+            </div>
+            <div class="keyboard-row" data-row="2">
+              <span></span>
+              <button class="vk-key" type="button" data-key="a" data-alternates="à|á|â|ä">A</button>
+              <button class="vk-key" type="button" data-key="s">S</button>
+              <button class="vk-key" type="button" data-key="d">D</button>
+              <button class="vk-key" type="button" data-key="f">F</button>
+              <button class="vk-key" type="button" data-key="g">G</button>
+              <button class="vk-key" type="button" data-key="h">H</button>
+              <button class="vk-key" type="button" data-key="j">J</button>
+              <button class="vk-key" type="button" data-key="k">K</button>
+              <button class="vk-key" type="button" data-key="l">L</button>
+              <button class="vk-key" type="button" data-action="delete" data-role="wide">⌦</button>
+            </div>
+            <div class="keyboard-row" data-row="3">
+              <button class="vk-key" type="button" data-action="move-left" data-role="wide">⇤</button>
+              <button class="vk-key" type="button" data-key="z">Z</button>
+              <button class="vk-key" type="button" data-key="x">X</button>
+              <button class="vk-key" type="button" data-key="c">C</button>
+              <button class="vk-key" type="button" data-key="v">V</button>
+              <button class="vk-key" type="button" data-key="b">B</button>
+              <button class="vk-key" type="button" data-key="n">N</button>
+              <button class="vk-key" type="button" data-key="m">M</button>
+              <button class="vk-key" type="button" data-action="move-right" data-role="wide">⇥</button>
+            </div>
+            <div class="keyboard-row" data-row="4">
+              <button class="vk-key" type="button" data-role="wide" data-key="123">123</button>
+              <button class="vk-key" type="button" data-role="wide" data-key="◆">◆</button>
+              <button class="vk-key" type="button" data-action="space" data-role="wide">Space</button>
+              <button class="vk-key" type="button" data-action="return" data-role="wide">Return</button>
+            </div>
+          </section>
+          <section class="compile-log" data-compile-log>{}</section>
+        </main>
+      </div>
+    </div>
+  </body>
+</html>

--- a/dist/ui/editor.js
+++ b/dist/ui/editor.js
@@ -1,0 +1,84 @@
+export class FauxEditor {
+  constructor(display) {
+    this.state = { text: "", caret: 0 };
+    this.subscribers = new Set();
+    this.display = display;
+    this.render();
+  }
+
+  subscribe(callback) {
+    this.subscribers.add(callback);
+    callback(this.state);
+    return () => {
+      this.subscribers.delete(callback);
+    };
+  }
+
+  insert(text) {
+    if (!text) {
+      return;
+    }
+    const before = this.state.text.slice(0, this.state.caret);
+    const after = this.state.text.slice(this.state.caret);
+    const nextText = `${before}${text}${after}`;
+    const nextCaret = this.state.caret + text.length;
+    this.updateState({ text: nextText, caret: nextCaret });
+  }
+
+  backspace() {
+    if (this.state.caret === 0) {
+      return;
+    }
+    const before = this.state.text.slice(0, this.state.caret - 1);
+    const after = this.state.text.slice(this.state.caret);
+    const nextCaret = this.state.caret - 1;
+    this.updateState({ text: `${before}${after}`, caret: nextCaret });
+  }
+
+  delete() {
+    if (this.state.caret >= this.state.text.length) {
+      return;
+    }
+    const before = this.state.text.slice(0, this.state.caret);
+    const after = this.state.text.slice(this.state.caret + 1);
+    this.updateState({ text: `${before}${after}`, caret: this.state.caret });
+  }
+
+  moveCaret(delta) {
+    const next = Math.max(0, Math.min(this.state.text.length, this.state.caret + delta));
+    if (next !== this.state.caret) {
+      this.updateState({ ...this.state, caret: next });
+    }
+  }
+
+  setText(text) {
+    const normalized = text ?? "";
+    this.updateState({ text: normalized, caret: Math.min(this.state.caret, normalized.length) });
+  }
+
+  getState() {
+    return { ...this.state };
+  }
+
+  updateState(next) {
+    this.state = next;
+    this.render();
+    this.subscribers.forEach((callback) => callback(this.getState()));
+  }
+
+  render() {
+    const before = this.state.text.slice(0, this.state.caret);
+    const caretChar = this.state.caret < this.state.text.length ? this.state.text[this.state.caret] : "\u00A0";
+    const after = this.state.text.slice(this.state.caret + 1);
+    this.display.innerHTML = `${this.escape(before)}<span class="editor-caret">${this.escape(caretChar)}</span>${this.escape(after)}`;
+  }
+
+  escape(value) {
+    return value
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/\u00A0/g, "&nbsp;")
+      .replace(/\n/g, "<br>");
+  }
+}

--- a/dist/ui/keyboard.js
+++ b/dist/ui/keyboard.js
@@ -1,0 +1,207 @@
+const REPEAT_DELAY = 350;
+const REPEAT_INTERVAL = 45;
+const LONG_PRESS_DELAY = 420;
+const SCRUB_PIXELS_PER_STEP = 10;
+const SCRUB_ACTIVATION_THRESHOLD = 6;
+
+export class VirtualKeyboard {
+  constructor(options) {
+    this.options = options;
+    this.editor = options.editor;
+    this.keys = this.scanKeys(options.root);
+    this.actives = new Map();
+    this.keys.forEach((key) => this.bindKey(key));
+    this.attachListeners();
+  }
+
+  scanKeys(root) {
+    const elements = Array.from(root.querySelectorAll("[data-key]"));
+    return elements.map((element) => {
+      const action = element.dataset.action ?? "character";
+      const value = element.dataset.key ?? "";
+      const alternates = (element.dataset.alternates ?? "")
+        .split("|")
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+      return { element, action, value, alternates };
+    });
+  }
+
+  bindKey(key) {
+    key.element.addEventListener("pointerdown", (event) => this.onPointerDown(event, key));
+    key.element.addEventListener("pointerenter", (event) => this.onPointerEnter(event, key));
+    key.element.addEventListener("pointerleave", (event) => this.onPointerLeave(event, key));
+    key.element.addEventListener("pointerup", (event) => this.onPointerUp(event));
+    key.element.addEventListener("contextmenu", (event) => event.preventDefault());
+  }
+
+  onPointerDown(event, key) {
+    if (event.button !== 0) {
+      return;
+    }
+    event.preventDefault();
+    key.element.setPointerCapture(event.pointerId);
+    key.element.classList.add("is-pressed");
+    const active = { key, pointerId: event.pointerId };
+    this.actives.set(event.pointerId, active);
+
+    if (key.action === "space") {
+      active.scrubOrigin = { x: event.clientX, caret: this.options.editor.getState().caret };
+    } else {
+      this.triggerKey(active, false);
+    }
+
+    if (key.alternates.length > 0) {
+      active.longPressTimeout = window.setTimeout(() => {
+        this.openAlternates(active);
+      }, LONG_PRESS_DELAY);
+    }
+
+    if (key.action !== "space") {
+      active.repeatTimeout = window.setTimeout(() => {
+        this.triggerKey(active, true);
+        active.repeatInterval = window.setInterval(() => this.triggerKey(active, true), REPEAT_INTERVAL);
+      }, REPEAT_DELAY);
+    }
+  }
+
+  onPointerEnter(event, key) {
+    if (!this.actives.has(event.pointerId)) {
+      return;
+    }
+    key.element.classList.add("is-hover");
+  }
+
+  onPointerLeave(event, key) {
+    if (!this.actives.has(event.pointerId)) {
+      key.element.classList.remove("is-hover");
+      return;
+    }
+    key.element.classList.remove("is-hover");
+    key.element.classList.remove("is-pressed");
+  }
+
+  onPointerUp(event) {
+    const active = this.actives.get(event.pointerId);
+    if (!active) {
+      return;
+    }
+
+    if (active.key.action === "space" && !active.scrubbed) {
+      this.editor.insert(" ");
+    }
+
+    this.cleanupActive(active);
+  }
+
+  cleanupActive(active) {
+    active.key.element.releasePointerCapture(active.pointerId);
+    active.key.element.classList.remove("is-pressed");
+    if (active.repeatTimeout) {
+      window.clearTimeout(active.repeatTimeout);
+    }
+    if (active.repeatInterval) {
+      window.clearInterval(active.repeatInterval);
+    }
+    if (active.longPressTimeout) {
+      window.clearTimeout(active.longPressTimeout);
+    }
+    if (active.popover) {
+      active.popover.remove();
+    }
+    this.actives.delete(active.pointerId);
+  }
+
+  triggerKey(active, repeating) {
+    const { key } = active;
+    if (active.popover) {
+      return;
+    }
+
+    switch (key.action) {
+      case "character":
+        if (key.value) {
+          this.editor.insert(key.value);
+        }
+        break;
+      case "backspace":
+        this.editor.backspace();
+        break;
+      case "delete":
+        this.editor.delete();
+        break;
+      case "space":
+        if (!active.scrubbed && repeating) {
+          this.editor.insert(" ");
+        }
+        break;
+      case "return":
+        this.editor.insert("\n");
+        break;
+      case "move-left":
+        this.editor.moveCaret(-1);
+        break;
+      case "move-right":
+        this.editor.moveCaret(1);
+        break;
+      default:
+        break;
+    }
+  }
+
+  openAlternates(active) {
+    const { key } = active;
+    if (active.popover || key.alternates.length === 0) {
+      return;
+    }
+    const popover = document.createElement("div");
+    popover.className = "vk-popover";
+    key.alternates.forEach((alternate) => {
+      const option = document.createElement("button");
+      option.type = "button";
+      option.textContent = alternate;
+      option.className = "vk-popover-key";
+      option.addEventListener("pointerdown", (event) => {
+        event.stopPropagation();
+        event.preventDefault();
+      });
+      option.addEventListener("pointerup", (event) => {
+        event.stopPropagation();
+        event.preventDefault();
+        this.editor.insert(alternate);
+        popover.remove();
+      });
+      popover.append(option);
+    });
+    key.element.append(popover);
+    active.popover = popover;
+  }
+
+  attachListeners() {
+    window.addEventListener("pointermove", (event) => this.onPointerMove(event));
+    window.addEventListener("pointerup", (event) => this.onPointerUp(event));
+  }
+
+  onPointerMove(event) {
+    const active = this.actives.get(event.pointerId);
+    if (!active) {
+      return;
+    }
+    if (active.scrubOrigin) {
+      const delta = event.clientX - active.scrubOrigin.x;
+      if (!active.scrubbed && Math.abs(delta) > SCRUB_ACTIVATION_THRESHOLD) {
+        active.scrubbed = true;
+      }
+      if (active.scrubbed) {
+        const steps = Math.trunc(delta / SCRUB_PIXELS_PER_STEP);
+        const target = active.scrubOrigin.caret + steps;
+        const current = this.editor.getState();
+        const clamped = Math.max(0, Math.min(current.text.length, target));
+        if (clamped !== current.caret) {
+          const diff = clamped - current.caret;
+          this.editor.moveCaret(diff);
+        }
+      }
+    }
+  }
+}

--- a/dist/ui/shell.js
+++ b/dist/ui/shell.js
@@ -1,0 +1,55 @@
+import { compileSeed } from "../compiler.js";
+import { FauxEditor } from "./editor.js";
+import { VirtualKeyboard } from "./keyboard.js";
+import { SuggestionStrip } from "./strip.js";
+
+const DEFAULT_SUGGESTIONS = ["ring slow tide", "spiral ghost trails", "one herald"];
+
+export function initShell() {
+  const drawer = document.querySelector("[data-shell-drawer]");
+  const drawerToggle = document.querySelector("[data-shell-drawer-toggle]");
+  const suggestionContainer = document.querySelector("[data-suggestion-strip]");
+  const keyboardRoot = document.querySelector("[data-keyboard]");
+  const editorDisplay = document.querySelector("[data-editor-display]");
+  const logOutput = document.querySelector("[data-compile-log]");
+  const modeToggles = Array.from(document.querySelectorAll("[data-mode]"));
+
+  if (!drawer || !drawerToggle || !suggestionContainer || !keyboardRoot || !editorDisplay || !logOutput) {
+    throw new Error("Shell markup missing required elements.");
+  }
+
+  const editor = new FauxEditor(editorDisplay);
+  new VirtualKeyboard({ root: keyboardRoot, editor });
+  const strip = new SuggestionStrip({ container: suggestionContainer, editor });
+  strip.setSuggestions(DEFAULT_SUGGESTIONS);
+
+  let mode = "seed";
+
+  drawerToggle.addEventListener("click", () => {
+    drawer.classList.toggle("is-open");
+  });
+
+  if (modeToggles.length > 0) {
+    modeToggles.forEach((toggle) => {
+      toggle.addEventListener("click", () => {
+        mode = toggle.dataset.mode ?? "seed";
+        modeToggles.forEach((btn) => btn.classList.toggle("is-active", btn === toggle));
+        runCompile(editor.getState().text);
+      });
+    });
+  }
+
+  editor.subscribe((state) => {
+    runCompile(state.text);
+  });
+
+  function runCompile(text) {
+    const trimmed = text.trim();
+    const result = compileSeed(trimmed, mode);
+    logOutput.textContent = JSON.stringify(result, null, 2);
+  }
+}
+
+window.addEventListener("DOMContentLoaded", () => {
+  initShell();
+});

--- a/dist/ui/strip.js
+++ b/dist/ui/strip.js
@@ -1,0 +1,42 @@
+export class SuggestionStrip {
+  constructor(config) {
+    this.container = config.container;
+    this.editor = config.editor;
+    this.bind();
+  }
+
+  setSuggestions(phrases) {
+    const pills = Array.from(this.container.querySelectorAll("button[data-suggestion]"));
+    pills.forEach((pill, index) => {
+      const suggestion = phrases[index];
+      if (suggestion) {
+        pill.textContent = suggestion;
+        pill.dataset.suggestion = suggestion;
+        pill.disabled = false;
+        pill.classList.remove("is-hidden");
+      } else {
+        pill.textContent = "";
+        pill.dataset.suggestion = "";
+        pill.disabled = true;
+        pill.classList.add("is-hidden");
+      }
+    });
+  }
+
+  bind() {
+    this.container.addEventListener("click", (event) => {
+      const target = event.target;
+      if (!target) {
+        return;
+      }
+      const button = target.closest("button[data-suggestion]");
+      if (!button || button.disabled) {
+        return;
+      }
+      const value = button.dataset.suggestion ?? "";
+      if (value) {
+        this.editor.insert(`${value} `);
+      }
+    });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "verse",
+  "version": "0.1.0",
+  "description": "Verse creative coding prototype",
+  "scripts": {
+    "build": "tsc"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  }
+}

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1,0 +1,392 @@
+export type CompilationMode = "seed" | "bloom";
+
+export interface VerseParams {
+  shape: string;
+  tide: number;
+  tremor: number;
+  trails: number;
+  pull: number;
+  count: number;
+  herald: boolean;
+  tempoHz: number;
+}
+
+export interface CompilationResult {
+  params: VerseParams;
+  engineVersion: string;
+  signature: string;
+}
+
+interface TokenEffect {
+  set?: Partial<VerseParams>;
+  delta?: Partial<Pick<VerseParams, "tide" | "tremor" | "trails" | "pull" | "tempoHz">>;
+}
+
+const ENGINE_VERSION = "2024.05-seed";
+
+const DEFAULT_PARAMS: VerseParams = {
+  shape: "field",
+  tide: 0.5,
+  tremor: 0.2,
+  trails: 0.6,
+  pull: 0.4,
+  count: 64,
+  herald: false,
+  tempoHz: 1.0,
+};
+
+const TOKEN_EFFECTS: Record<string, TokenEffect> = {
+  ring: { set: { shape: "circle" }, delta: { pull: 0.2 } },
+  spiral: { set: { shape: "spiral" }, delta: { tide: 0.25 } },
+  wave: { set: { shape: "wave" } },
+  line: { set: { shape: "line" } },
+  static: { delta: { tremor: 0.25 } },
+  noise: { delta: { tremor: 0.25 } },
+  scatter: { delta: { tremor: 0.25 } },
+  slow: { set: { tide: 0.25 } },
+  fast: { set: { tide: 0.75 } },
+  calm: { set: { tide: 0.3 } },
+  rush: { set: { tide: 0.85 } },
+  short: { set: { trails: 0.3 } },
+  long: { set: { trails: 0.85 } },
+  ghost: { set: { trails: 0.95 } },
+  trails: { delta: { trails: 0.1 } },
+  few: { set: { count: 12 } },
+  some: { set: { count: 32 } },
+  many: { set: { count: 128 } },
+  thousand: { set: { count: 1000 } },
+  herald: { set: { herald: true, count: 1 } },
+  red: { set: { herald: true, count: 1 } },
+  tempo: { set: { tempoHz: 1.0 } },
+  pulse: { set: { tempoHz: 2.0 } },
+  breathe: { set: { tempoHz: 0.5 } },
+  beat: { set: { tempoHz: 1.5 } },
+};
+
+const NUMBER_PATTERN = /^\d+$/;
+
+export function compileSeed(seed: string, mode: CompilationMode, engineVersion: string = ENGINE_VERSION): CompilationResult {
+  const tokens = tokenize(seed);
+  const params = mode === "seed" ? compileSeedMode(tokens) : compileBloomMode(tokens);
+  const signature = sha256(`${seed}|${engineVersion}|${JSON.stringify(params)}`);
+  return { params, engineVersion, signature };
+}
+
+function tokenize(seed: string): string[] {
+  return seed
+    .toLowerCase()
+    .split(/[^a-z0-9]+/g)
+    .map((token) => token.trim())
+    .filter(Boolean);
+}
+
+interface SeedAccumulatorEntry<T> {
+  value: T;
+  conflict: boolean;
+  applied: boolean;
+}
+
+function compileSeedMode(tokens: string[]): VerseParams {
+  const accumulator: { [K in keyof VerseParams]: SeedAccumulatorEntry<VerseParams[K]> } = {
+    shape: { value: DEFAULT_PARAMS.shape, conflict: false, applied: false },
+    tide: { value: DEFAULT_PARAMS.tide, conflict: false, applied: false },
+    tremor: { value: DEFAULT_PARAMS.tremor, conflict: false, applied: false },
+    trails: { value: DEFAULT_PARAMS.trails, conflict: false, applied: false },
+    pull: { value: DEFAULT_PARAMS.pull, conflict: false, applied: false },
+    count: { value: DEFAULT_PARAMS.count, conflict: false, applied: false },
+    herald: { value: DEFAULT_PARAMS.herald, conflict: false, applied: false },
+    tempoHz: { value: DEFAULT_PARAMS.tempoHz, conflict: false, applied: false },
+  };
+
+  tokens.forEach((token) => {
+    if (NUMBER_PATTERN.test(token)) {
+      applySeedValue(accumulator, "count", parseInt(token, 10));
+      return;
+    }
+
+    if (token === "tempo" && tokens.includes("hz")) {
+      return;
+    }
+
+    const effect = TOKEN_EFFECTS[token];
+    if (!effect) {
+      return;
+    }
+
+    if (effect.set) {
+      for (const [key, rawValue] of Object.entries(effect.set) as [keyof VerseParams, VerseParams[keyof VerseParams]][]) {
+        applySeedValue(accumulator, key, rawValue);
+      }
+    }
+
+    if (effect.delta) {
+      for (const [key, delta] of Object.entries(effect.delta) as [keyof VerseParams, number][]) {
+        const entry = accumulator[key];
+        const next = typeof entry.value === "number" ? clampNumber((entry.value as number) + delta, 0, 1.5) : entry.value;
+        entry.value = next as VerseParams[typeof key];
+        entry.applied = true;
+      }
+    }
+  });
+
+  (Object.keys(accumulator) as (keyof VerseParams)[]).forEach((key) => {
+    const entry = accumulator[key];
+    if (entry.conflict) {
+      entry.value = DEFAULT_PARAMS[key];
+    }
+  });
+
+  return {
+    shape: accumulator.shape.value,
+    tide: accumulator.tide.value,
+    tremor: accumulator.tremor.value,
+    trails: accumulator.trails.value,
+    pull: accumulator.pull.value,
+    count: accumulator.count.value,
+    herald: accumulator.herald.value,
+    tempoHz: accumulator.tempoHz.value,
+  };
+}
+
+function applySeedValue<K extends keyof VerseParams>(
+  accumulator: { [P in keyof VerseParams]: SeedAccumulatorEntry<VerseParams[P]> },
+  key: K,
+  value: VerseParams[K]
+): void {
+  const entry = accumulator[key];
+  if (!entry.applied) {
+    entry.value = value;
+    entry.applied = true;
+    return;
+  }
+  if (isSame(entry.value, value)) {
+    return;
+  }
+  entry.conflict = true;
+}
+
+interface BloomAccumulatorEntry<T> {
+  contributions: Array<{ value: T; weight: number }>;
+}
+
+function compileBloomMode(tokens: string[]): VerseParams {
+  const accumulator: { [K in keyof VerseParams]: BloomAccumulatorEntry<VerseParams[K]> } = {
+    shape: { contributions: [] },
+    tide: { contributions: [] },
+    tremor: { contributions: [] },
+    trails: { contributions: [] },
+    pull: { contributions: [] },
+    count: { contributions: [] },
+    herald: { contributions: [] },
+    tempoHz: { contributions: [] },
+  };
+
+  tokens.forEach((token) => {
+    if (NUMBER_PATTERN.test(token)) {
+      accumulator.count.contributions.push({ value: parseInt(token, 10) as VerseParams["count"], weight: 1 });
+      return;
+    }
+
+    const effect = TOKEN_EFFECTS[token];
+    if (!effect) {
+      return;
+    }
+
+    if (effect.set) {
+      for (const [key, rawValue] of Object.entries(effect.set) as [keyof VerseParams, VerseParams[keyof VerseParams]][]) {
+        accumulator[key].contributions.push({ value: rawValue, weight: 1 });
+      }
+    }
+
+    if (effect.delta) {
+      for (const [key, delta] of Object.entries(effect.delta) as [keyof VerseParams, number][]) {
+        const base = DEFAULT_PARAMS[key] as number;
+        accumulator[key].contributions.push({ value: (base + delta) as VerseParams[keyof VerseParams], weight: 0.6 });
+      }
+    }
+  });
+
+  return {
+    shape: pickMode(accumulator.shape, DEFAULT_PARAMS.shape),
+    tide: blendNumeric(accumulator.tide, DEFAULT_PARAMS.tide),
+    tremor: blendNumeric(accumulator.tremor, DEFAULT_PARAMS.tremor),
+    trails: blendNumeric(accumulator.trails, DEFAULT_PARAMS.trails),
+    pull: blendNumeric(accumulator.pull, DEFAULT_PARAMS.pull),
+    count: blendNumeric(accumulator.count, DEFAULT_PARAMS.count, { clampMax: 2000 }),
+    herald: blendBoolean(accumulator.herald, DEFAULT_PARAMS.herald),
+    tempoHz: blendNumeric(accumulator.tempoHz, DEFAULT_PARAMS.tempoHz, { clampMax: 6 }),
+  };
+}
+
+function pickMode(entry: BloomAccumulatorEntry<string>, fallback: string): string {
+  if (entry.contributions.length === 0) {
+    return fallback;
+  }
+  const buckets = new Map<string, number>();
+  entry.contributions.forEach(({ value, weight }) => {
+    buckets.set(value, (buckets.get(value) ?? 0) + weight);
+  });
+  let best = fallback;
+  let bestWeight = -Infinity;
+  buckets.forEach((weight, key) => {
+    if (weight > bestWeight) {
+      bestWeight = weight;
+      best = key;
+    }
+  });
+  return best;
+}
+
+function blendNumeric(
+  entry: BloomAccumulatorEntry<number>,
+  fallback: number,
+  options: { clampMin?: number; clampMax?: number } = {}
+): number {
+  if (entry.contributions.length === 0) {
+    return fallback;
+  }
+  let weightSum = 0;
+  let weightedValue = 0;
+  entry.contributions.forEach(({ value, weight }) => {
+    weightSum += weight;
+    weightedValue += value * weight;
+  });
+  const raw = weightSum > 0 ? weightedValue / weightSum : fallback;
+  const min = options.clampMin ?? 0;
+  const max = options.clampMax ?? 1.5;
+  return clampNumber(raw, min, max);
+}
+
+function blendBoolean(entry: BloomAccumulatorEntry<boolean>, fallback: boolean): boolean {
+  if (entry.contributions.length === 0) {
+    return fallback;
+  }
+  let score = fallback ? 0.5 : 0;
+  entry.contributions.forEach(({ value, weight }) => {
+    score += (value ? 1 : -1) * weight;
+  });
+  return score > 0.5;
+}
+
+function clampNumber(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function isSame(current: unknown, next: unknown): boolean {
+  if (typeof current === "number" && typeof next === "number") {
+    return Math.abs(current - next) < 1e-6;
+  }
+  return current === next;
+}
+
+function sha256(input: string): string {
+  const data = new TextEncoder().encode(input);
+  const hash = sha256Buffer(data);
+  return Array.from(hash)
+    .map((value) => value.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function sha256Buffer(data: Uint8Array): Uint8Array {
+  const K = new Uint32Array([
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+  ]);
+
+  const H = new Uint32Array([
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+  ]);
+
+  const padded = pad(data);
+  const view = new DataView(padded.buffer);
+
+  const w = new Uint32Array(64);
+
+  for (let offset = 0; offset < padded.byteLength; offset += 64) {
+    for (let i = 0; i < 16; i += 1) {
+      w[i] = view.getUint32(offset + i * 4);
+    }
+    for (let i = 16; i < 64; i += 1) {
+      const s0 = rightRotate(w[i - 15], 7) ^ rightRotate(w[i - 15], 18) ^ (w[i - 15] >>> 3);
+      const s1 = rightRotate(w[i - 2], 17) ^ rightRotate(w[i - 2], 19) ^ (w[i - 2] >>> 10);
+      w[i] = (w[i - 16] + s0 + w[i - 7] + s1) >>> 0;
+    }
+
+    let a = H[0];
+    let b = H[1];
+    let c = H[2];
+    let d = H[3];
+    let e = H[4];
+    let f = H[5];
+    let g = H[6];
+    let h = H[7];
+
+    for (let i = 0; i < 64; i += 1) {
+      const S1 = rightRotate(e, 6) ^ rightRotate(e, 11) ^ rightRotate(e, 25);
+      const ch = (e & f) ^ (~e & g);
+      const temp1 = (h + S1 + ch + K[i] + w[i]) >>> 0;
+      const S0 = rightRotate(a, 2) ^ rightRotate(a, 13) ^ rightRotate(a, 22);
+      const maj = (a & b) ^ (a & c) ^ (b & c);
+      const temp2 = (S0 + maj) >>> 0;
+
+      h = g;
+      g = f;
+      f = e;
+      e = (d + temp1) >>> 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (temp1 + temp2) >>> 0;
+    }
+
+    H[0] = (H[0] + a) >>> 0;
+    H[1] = (H[1] + b) >>> 0;
+    H[2] = (H[2] + c) >>> 0;
+    H[3] = (H[3] + d) >>> 0;
+    H[4] = (H[4] + e) >>> 0;
+    H[5] = (H[5] + f) >>> 0;
+    H[6] = (H[6] + g) >>> 0;
+    H[7] = (H[7] + h) >>> 0;
+  }
+
+  const out = new Uint8Array(32);
+  for (let i = 0; i < H.length; i += 1) {
+    out[i * 4] = (H[i] >>> 24) & 0xff;
+    out[i * 4 + 1] = (H[i] >>> 16) & 0xff;
+    out[i * 4 + 2] = (H[i] >>> 8) & 0xff;
+    out[i * 4 + 3] = H[i] & 0xff;
+  }
+  return out;
+}
+
+function pad(data: Uint8Array): Uint8Array {
+  const length = data.length;
+  const withOne = new Uint8Array(length + 1);
+  withOne.set(data);
+  withOne[length] = 0x80;
+
+  let paddedLength = withOne.length;
+  while ((paddedLength % 64) !== 56) {
+    paddedLength += 1;
+  }
+
+  const padded = new Uint8Array(paddedLength + 8);
+  padded.set(withOne);
+
+  const bitLength = length * 8;
+  for (let i = 0; i < 8; i += 1) {
+    padded[paddedLength + 7 - i] = bitLength >>> (i * 8);
+  }
+
+  return padded;
+}
+
+function rightRotate(value: number, bits: number): number {
+  return (value >>> bits) | (value << (32 - bits));
+}

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,0 +1,86 @@
+import { VerseParams } from "./compiler";
+
+export interface EngineFrame {
+  timeMs: number;
+  deltaMs: number;
+}
+
+export class VerseEngine {
+  private readonly canvas: HTMLCanvasElement;
+  private readonly context: CanvasRenderingContext2D;
+  private animationFrame: number | null = null;
+  private lastTimestamp = 0;
+  private params: VerseParams | null = null;
+
+  constructor(canvas: HTMLCanvasElement) {
+    const context = canvas.getContext("2d", { alpha: false });
+    if (!context) {
+      throw new Error("Canvas 2D context unavailable");
+    }
+    this.canvas = canvas;
+    this.context = context;
+    this.configure();
+  }
+
+  configure(): void {
+    const { devicePixelRatio } = window;
+    const width = this.canvas.clientWidth;
+    const height = this.canvas.clientHeight;
+    this.canvas.width = Math.floor(width * devicePixelRatio);
+    this.canvas.height = Math.floor(height * devicePixelRatio);
+    this.context.scale(devicePixelRatio, devicePixelRatio);
+  }
+
+  setParams(params: VerseParams): void {
+    this.params = params;
+  }
+
+  start(): void {
+    if (this.animationFrame !== null) {
+      return;
+    }
+    this.lastTimestamp = performance.now();
+    const tick = (timestamp: number) => {
+      const delta = timestamp - this.lastTimestamp;
+      this.lastTimestamp = timestamp;
+      this.draw({ timeMs: timestamp, deltaMs: delta });
+      this.animationFrame = window.requestAnimationFrame(tick);
+    };
+    this.animationFrame = window.requestAnimationFrame(tick);
+  }
+
+  stop(): void {
+    if (this.animationFrame !== null) {
+      window.cancelAnimationFrame(this.animationFrame);
+      this.animationFrame = null;
+    }
+  }
+
+  private draw(frame: EngineFrame): void {
+    const { context, canvas } = this;
+    context.fillStyle = "rgba(8, 8, 12, 0.6)";
+    context.fillRect(0, 0, canvas.width, canvas.height);
+
+    if (!this.params) {
+      return;
+    }
+
+    const centerX = canvas.width / 2;
+    const centerY = canvas.height / 2;
+    const count = Math.max(1, Math.floor(this.params.count));
+    const radius = Math.min(centerX, centerY) * 0.6;
+    const tempo = this.params.tempoHz;
+    const time = frame.timeMs / 1000;
+
+    for (let i = 0; i < count; i += 1) {
+      const angle = ((i / count) * Math.PI * 2 + time * tempo) % (Math.PI * 2);
+      const jitter = this.params.tremor * Math.sin(time * 3.1 + i);
+      const x = centerX + Math.cos(angle) * (radius + jitter * 40);
+      const y = centerY + Math.sin(angle) * (radius + jitter * 40);
+      context.fillStyle = this.params.herald && i === 0 ? "#ff5555" : "#d0d7ff";
+      context.beginPath();
+      context.arc(x, y, this.params.pull * 6 + 2, 0, Math.PI * 2);
+      context.fill();
+    }
+  }
+}

--- a/src/ui/editor.ts
+++ b/src/ui/editor.ts
@@ -1,0 +1,93 @@
+export interface EditorState {
+  text: string;
+  caret: number;
+}
+
+export type EditorSubscriber = (state: EditorState) => void;
+
+export class FauxEditor {
+  private state: EditorState = { text: "", caret: 0 };
+  private readonly subscribers = new Set<EditorSubscriber>();
+  private readonly display: HTMLElement;
+
+  constructor(display: HTMLElement) {
+    this.display = display;
+    this.render();
+  }
+
+  subscribe(callback: EditorSubscriber): () => void {
+    this.subscribers.add(callback);
+    callback(this.state);
+    return () => {
+      this.subscribers.delete(callback);
+    };
+  }
+
+  insert(text: string): void {
+    if (!text) {
+      return;
+    }
+    const before = this.state.text.slice(0, this.state.caret);
+    const after = this.state.text.slice(this.state.caret);
+    const nextText = `${before}${text}${after}`;
+    const nextCaret = this.state.caret + text.length;
+    this.updateState({ text: nextText, caret: nextCaret });
+  }
+
+  backspace(): void {
+    if (this.state.caret === 0) {
+      return;
+    }
+    const before = this.state.text.slice(0, this.state.caret - 1);
+    const after = this.state.text.slice(this.state.caret);
+    const nextCaret = this.state.caret - 1;
+    this.updateState({ text: `${before}${after}`, caret: nextCaret });
+  }
+
+  delete(): void {
+    if (this.state.caret >= this.state.text.length) {
+      return;
+    }
+    const before = this.state.text.slice(0, this.state.caret);
+    const after = this.state.text.slice(this.state.caret + 1);
+    this.updateState({ text: `${before}${after}`, caret: this.state.caret });
+  }
+
+  moveCaret(delta: number): void {
+    const next = Math.max(0, Math.min(this.state.text.length, this.state.caret + delta));
+    if (next !== this.state.caret) {
+      this.updateState({ ...this.state, caret: next });
+    }
+  }
+
+  setText(text: string): void {
+    const normalized = text ?? "";
+    this.updateState({ text: normalized, caret: Math.min(this.state.caret, normalized.length) });
+  }
+
+  getState(): EditorState {
+    return { ...this.state };
+  }
+
+  private updateState(next: EditorState): void {
+    this.state = next;
+    this.render();
+    this.subscribers.forEach((callback) => callback(this.getState()));
+  }
+
+  private render(): void {
+    const before = this.state.text.slice(0, this.state.caret);
+    const caretChar = this.state.caret < this.state.text.length ? this.state.text[this.state.caret] : "\u00A0";
+    const after = this.state.text.slice(this.state.caret + 1);
+    this.display.innerHTML = `${this.escape(before)}<span class="editor-caret">${this.escape(caretChar)}</span>${this.escape(after)}`;
+  }
+
+  private escape(value: string): string {
+    return value
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/\u00A0/g, "&nbsp;")
+      .replace(/\n/g, "<br>");
+  }
+}

--- a/src/ui/keyboard.ts
+++ b/src/ui/keyboard.ts
@@ -1,0 +1,246 @@
+import { FauxEditor } from "./editor";
+
+type KeyAction =
+  | "character"
+  | "backspace"
+  | "delete"
+  | "space"
+  | "return"
+  | "move-left"
+  | "move-right";
+
+interface VirtualKey {
+  element: HTMLElement;
+  action: KeyAction;
+  value: string;
+  alternates: string[];
+}
+
+interface ActiveKey {
+  key: VirtualKey;
+  pointerId: number;
+  repeatTimeout?: number;
+  repeatInterval?: number;
+  longPressTimeout?: number;
+  scrubOrigin?: {
+    x: number;
+    caret: number;
+  };
+  scrubbed?: boolean;
+  popover?: HTMLElement;
+}
+
+const REPEAT_DELAY = 350;
+const REPEAT_INTERVAL = 45;
+const LONG_PRESS_DELAY = 420;
+const SCRUB_PIXELS_PER_STEP = 10;
+const SCRUB_ACTIVATION_THRESHOLD = 6;
+
+export interface VirtualKeyboardOptions {
+  root: HTMLElement;
+  editor: FauxEditor;
+}
+
+export class VirtualKeyboard {
+  private readonly keys: VirtualKey[] = [];
+  private readonly actives = new Map<number, ActiveKey>();
+  private readonly editor: FauxEditor;
+
+  constructor(private readonly options: VirtualKeyboardOptions) {
+    this.editor = options.editor;
+    this.keys = this.scanKeys(options.root);
+    this.keys.forEach((key) => this.bindKey(key));
+    this.attachListeners();
+  }
+
+  private scanKeys(root: HTMLElement): VirtualKey[] {
+    const elements = Array.from(root.querySelectorAll<HTMLElement>("[data-key]"));
+    return elements.map((element) => {
+      const action = (element.dataset.action ?? "character") as KeyAction;
+      const value = element.dataset.key ?? "";
+      const alternates = (element.dataset.alternates ?? "")
+        .split("|")
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+      return { element, action, value, alternates };
+    });
+  }
+
+  private bindKey(key: VirtualKey): void {
+    key.element.addEventListener("pointerdown", (event) => this.onPointerDown(event, key));
+    key.element.addEventListener("pointerenter", (event) => this.onPointerEnter(event, key));
+    key.element.addEventListener("pointerleave", (event) => this.onPointerLeave(event, key));
+    key.element.addEventListener("pointerup", (event) => this.onPointerUp(event));
+    key.element.addEventListener("contextmenu", (event) => event.preventDefault());
+  }
+
+  private onPointerDown(event: PointerEvent, key: VirtualKey): void {
+    if (event.button !== 0) {
+      return;
+    }
+    event.preventDefault();
+    key.element.setPointerCapture(event.pointerId);
+    key.element.classList.add("is-pressed");
+    const active: ActiveKey = { key, pointerId: event.pointerId };
+    this.actives.set(event.pointerId, active);
+
+    if (key.action === "space") {
+      active.scrubOrigin = { x: event.clientX, caret: this.options.editor.getState().caret };
+    } else {
+      this.triggerKey(active, false);
+    }
+
+    if (key.alternates.length > 0) {
+      active.longPressTimeout = window.setTimeout(() => {
+        this.openAlternates(active);
+      }, LONG_PRESS_DELAY);
+    }
+
+    if (key.action !== "space") {
+      active.repeatTimeout = window.setTimeout(() => {
+        this.triggerKey(active, true);
+        active.repeatInterval = window.setInterval(() => this.triggerKey(active, true), REPEAT_INTERVAL);
+      }, REPEAT_DELAY);
+    }
+  }
+
+  private onPointerEnter(event: PointerEvent, key: VirtualKey): void {
+    if (!this.actives.has(event.pointerId)) {
+      return;
+    }
+    key.element.classList.add("is-hover");
+  }
+
+  private onPointerLeave(event: PointerEvent, key: VirtualKey): void {
+    if (!this.actives.has(event.pointerId)) {
+      key.element.classList.remove("is-hover");
+      return;
+    }
+    key.element.classList.remove("is-hover");
+    key.element.classList.remove("is-pressed");
+  }
+
+  private onPointerUp(event: PointerEvent): void {
+    const active = this.actives.get(event.pointerId);
+    if (!active) {
+      return;
+    }
+
+    if (active.key.action === "space" && !active.scrubbed) {
+      this.editor.insert(" ");
+    }
+
+    this.cleanupActive(active);
+  }
+
+  private cleanupActive(active: ActiveKey): void {
+    active.key.element.releasePointerCapture(active.pointerId);
+    active.key.element.classList.remove("is-pressed");
+    if (active.repeatTimeout) {
+      window.clearTimeout(active.repeatTimeout);
+    }
+    if (active.repeatInterval) {
+      window.clearInterval(active.repeatInterval);
+    }
+    if (active.longPressTimeout) {
+      window.clearTimeout(active.longPressTimeout);
+    }
+    if (active.popover) {
+      active.popover.remove();
+    }
+    this.actives.delete(active.pointerId);
+  }
+
+  private triggerKey(active: ActiveKey, repeating: boolean): void {
+    const { key } = active;
+    if (active.popover) {
+      return;
+    }
+
+    switch (key.action) {
+      case "character":
+        if (key.value) {
+          this.editor.insert(key.value);
+        }
+        break;
+      case "backspace":
+        this.editor.backspace();
+        break;
+      case "delete":
+        this.editor.delete();
+        break;
+      case "space":
+        if (!active.scrubbed && repeating) {
+          this.editor.insert(" ");
+        }
+        break;
+      case "return":
+        this.editor.insert("\n");
+        break;
+      case "move-left":
+        this.editor.moveCaret(-1);
+        break;
+      case "move-right":
+        this.editor.moveCaret(1);
+        break;
+      default:
+        break;
+    }
+  }
+
+  private openAlternates(active: ActiveKey): void {
+    const { key } = active;
+    if (active.popover || key.alternates.length === 0) {
+      return;
+    }
+    const popover = document.createElement("div");
+    popover.className = "vk-popover";
+    key.alternates.forEach((alternate) => {
+      const option = document.createElement("button");
+      option.type = "button";
+      option.textContent = alternate;
+      option.className = "vk-popover-key";
+      option.addEventListener("pointerdown", (event) => {
+        event.stopPropagation();
+        event.preventDefault();
+      });
+      option.addEventListener("pointerup", (event) => {
+        event.stopPropagation();
+        event.preventDefault();
+        this.editor.insert(alternate);
+        popover.remove();
+      });
+      popover.append(option);
+    });
+    key.element.append(popover);
+    active.popover = popover;
+  }
+
+  private attachListeners(): void {
+    window.addEventListener("pointermove", (event) => this.onPointerMove(event));
+    window.addEventListener("pointerup", (event) => this.onPointerUp(event));
+  }
+
+  private onPointerMove(event: PointerEvent): void {
+    const active = this.actives.get(event.pointerId);
+    if (!active) {
+      return;
+    }
+    if (active.scrubOrigin) {
+      const delta = event.clientX - active.scrubOrigin.x;
+      if (!active.scrubbed && Math.abs(delta) > SCRUB_ACTIVATION_THRESHOLD) {
+        active.scrubbed = true;
+      }
+      if (active.scrubbed) {
+        const steps = Math.trunc(delta / SCRUB_PIXELS_PER_STEP);
+        const target = active.scrubOrigin.caret + steps;
+        const current = this.editor.getState();
+        const clamped = Math.max(0, Math.min(current.text.length, target));
+        if (clamped !== current.caret) {
+          const diff = clamped - current.caret;
+          this.editor.moveCaret(diff);
+        }
+      }
+    }
+  }
+}

--- a/src/ui/shell.ts
+++ b/src/ui/shell.ts
@@ -1,0 +1,55 @@
+import { compileSeed, CompilationMode } from "../compiler";
+import { FauxEditor } from "./editor";
+import { VirtualKeyboard } from "./keyboard";
+import { SuggestionStrip } from "./strip";
+
+const DEFAULT_SUGGESTIONS = ["ring slow tide", "spiral ghost trails", "one herald"];
+
+export function initShell(): void {
+  const drawer = document.querySelector<HTMLElement>("[data-shell-drawer]");
+  const drawerToggle = document.querySelector<HTMLButtonElement>("[data-shell-drawer-toggle]");
+  const suggestionContainer = document.querySelector<HTMLElement>("[data-suggestion-strip]");
+  const keyboardRoot = document.querySelector<HTMLElement>("[data-keyboard]");
+  const editorDisplay = document.querySelector<HTMLElement>("[data-editor-display]");
+  const logOutput = document.querySelector<HTMLElement>("[data-compile-log]");
+  const modeToggles = Array.from(document.querySelectorAll<HTMLButtonElement>("[data-mode]"));
+
+  if (!drawer || !drawerToggle || !suggestionContainer || !keyboardRoot || !editorDisplay || !logOutput) {
+    throw new Error("Shell markup missing required elements.");
+  }
+
+  const editor = new FauxEditor(editorDisplay);
+  new VirtualKeyboard({ root: keyboardRoot, editor });
+  const strip = new SuggestionStrip({ container: suggestionContainer, editor });
+  strip.setSuggestions(DEFAULT_SUGGESTIONS);
+
+  let mode: CompilationMode = "seed";
+
+  drawerToggle.addEventListener("click", () => {
+    drawer.classList.toggle("is-open");
+  });
+
+  if (modeToggles.length > 0) {
+    modeToggles.forEach((toggle) => {
+      toggle.addEventListener("click", () => {
+        mode = (toggle.dataset.mode as CompilationMode) ?? "seed";
+        modeToggles.forEach((btn) => btn.classList.toggle("is-active", btn === toggle));
+        runCompile(editor.getState().text);
+      });
+    });
+  }
+
+  editor.subscribe((state) => {
+    runCompile(state.text);
+  });
+
+  function runCompile(text: string): void {
+    const trimmed = text.trim();
+    const result = compileSeed(trimmed, mode);
+    logOutput.textContent = JSON.stringify(result, null, 2);
+  }
+}
+
+window.addEventListener("DOMContentLoaded", () => {
+  initShell();
+});

--- a/src/ui/strip.ts
+++ b/src/ui/strip.ts
@@ -1,0 +1,52 @@
+import { FauxEditor } from "./editor";
+
+interface SuggestionConfig {
+  container: HTMLElement;
+  editor: FauxEditor;
+}
+
+export class SuggestionStrip {
+  private readonly container: HTMLElement;
+  private readonly editor: FauxEditor;
+
+  constructor(config: SuggestionConfig) {
+    this.container = config.container;
+    this.editor = config.editor;
+    this.bind();
+  }
+
+  setSuggestions(phrases: string[]): void {
+    const pills = Array.from(this.container.querySelectorAll<HTMLButtonElement>("button[data-suggestion]"));
+    pills.forEach((pill, index) => {
+      const suggestion = phrases[index];
+      if (suggestion) {
+        pill.textContent = suggestion;
+        pill.dataset.suggestion = suggestion;
+        pill.disabled = false;
+        pill.classList.remove("is-hidden");
+      } else {
+        pill.textContent = "";
+        pill.dataset.suggestion = "";
+        pill.disabled = true;
+        pill.classList.add("is-hidden");
+      }
+    });
+  }
+
+  private bind(): void {
+    this.container.addEventListener("click", (event) => {
+      const target = event.target as HTMLElement | null;
+      if (!target) {
+        return;
+      }
+      const button = target.closest<HTMLButtonElement>("button[data-suggestion]");
+      if (!button || button.disabled) {
+        return;
+      }
+      const value = button.dataset.suggestion ?? "";
+      if (value) {
+        this.editor.insert(`${value} `);
+      }
+    });
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "Node",
+    "lib": ["DOM", "ES2020"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- add a self-contained `dist/shell_keyboard.html` demo with the Verse shell layout, suggestion strip, and Apple-style keyboard clone
- implement TypeScript modules for the faux editor, keyboard interactions, shell wiring, and a polysemous compiler that returns deterministic parameters and signatures
- stub a canvas engine and emit browser-ready ES modules under `dist/` for immediate manual testing

## Testing
- npm install *(fails: 403 Forbidden fetching typescript from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68f4d31aa5b08331b21f38865a4251b3